### PR TITLE
Remove LiveReload from root

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,5 @@
 import {
   Links,
-  LiveReload,
   Meta,
   Outlet,
   Scripts,
@@ -26,7 +25,6 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
       </body>
     </html>
   );


### PR DESCRIPTION
Use of LiveReload is deprecated when Remix is used with Vite